### PR TITLE
[SUBS-535] Change ValidationResult object

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-version '1.7.0-SNAPSHOT'
+version '1.8.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'

--- a/src/main/java/uk/ac/ebi/subs/validator/data/ValidationResult.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/data/ValidationResult.java
@@ -2,13 +2,11 @@ package uk.ac.ebi.subs.validator.data;
 
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,11 +30,7 @@ public class ValidationResult extends AbstractValidationResult implements Identi
     @Indexed
     private String submissionId;
 
-    @Transient
-    private List<ValidationAuthor> validationAuthors;
-
-    private List<SingleValidationResult> validationResults = new ArrayList<>();
-    private Map<ValidationAuthor, Boolean> expectedResults = new HashMap<>();
+    private Map<ValidationAuthor, List<SingleValidationResult>> expectedResults = new HashMap<>();
 
     @Override
     public String getUuid() {
@@ -66,27 +60,11 @@ public class ValidationResult extends AbstractValidationResult implements Identi
         this.submissionId = submissionId;
     }
 
-    public List<ValidationAuthor> getValidationAuthors() {
-        return validationAuthors;
-    }
-
-    public void setValidationAuthors(List<ValidationAuthor> validationAuthors) {
-        this.validationAuthors = validationAuthors;
-    }
-
-    public List<SingleValidationResult> getValidationResults() {
-        return validationResults;
-    }
-
-    public void setValidationResults(List<SingleValidationResult> validationResults) {
-        this.validationResults = validationResults;
-    }
-
-    public Map<ValidationAuthor, Boolean> getExpectedResults() {
+    public Map<ValidationAuthor, List<SingleValidationResult>> getExpectedResults() {
         return expectedResults;
     }
 
-    public void setExpectedResults(Map<ValidationAuthor, Boolean> expectedResults) {
+    public void setExpectedResults(Map<ValidationAuthor, List<SingleValidationResult>> expectedResults) {
         this.expectedResults = expectedResults;
     }
 }

--- a/src/test/java/uk/ac/ebi/subs/validator/repository/ValidationResultRepositoryTest.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/repository/ValidationResultRepositoryTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.subs.validator.data.SingleValidationResult;
 import uk.ac.ebi.subs.validator.data.ValidationAuthor;
 import uk.ac.ebi.subs.validator.data.ValidationResult;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,10 +47,10 @@ public class ValidationResultRepositoryTest {
 
     @Before
     public void buildUp() {
-        Map<ValidationAuthor, Boolean> expectedResults = new HashMap<>();
-        expectedResults.put(ValidationAuthor.Biosamples, true);
-        expectedResults.put(ValidationAuthor.Taxonomy, false);
-        expectedResults.put(ValidationAuthor.Ena, false);
+        Map<ValidationAuthor, List<SingleValidationResult>> expectedResults = new HashMap<>();
+        expectedResults.put(ValidationAuthor.Biosamples, new ArrayList<>());
+        expectedResults.put(ValidationAuthor.Taxonomy, new ArrayList<>());
+        expectedResults.put(ValidationAuthor.Ena, new ArrayList<>());
 
         // First
         validationResult = new ValidationResult();
@@ -80,7 +82,7 @@ public class ValidationResultRepositoryTest {
         ValidationResult retrievedResult = validationResultRepository.findOne(validationResult.getUuid());
         System.out.println(retrievedResult);
 
-        assertThat(retrievedResult.getExpectedResults().get(ValidationAuthor.Biosamples), is(true));
+        assertThat(retrievedResult.getExpectedResults().get(ValidationAuthor.Biosamples), is(new ArrayList<>()));
     }
 
     @Test


### PR DESCRIPTION
**WARN** This pull request contains changes on the data model that may break other components when upgrading to use this new version `1.8.0-SNAPSHOT`.

The **ValidationResult** object now contains a map with an entry for each validator that will collect the expected _SingleValidationResult_ objects generated by it:
`{ValidationAuthor : List<SingleValidationResult>}`